### PR TITLE
Test improvements about class name and assertions

### DIFF
--- a/tests/BlockTest.php
+++ b/tests/BlockTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  * @author Rene Korss <rene.korss@gmail.com>
  */
 
-final class BlockTests extends TestCase
+final class BlockTest extends TestCase
 {
     public function testCanCreateGenesisBlock() : void
     {
@@ -31,7 +31,7 @@ final class BlockTests extends TestCase
         $this->assertTrue($genesisBlock->isValid());
 
         // Can set and retrieve data
-        $this->assertEquals($genesisBlock->getData(), $testData);
+        $this->assertSame($testData, $genesisBlock->getData());
     }
 
     public function testCanCreateBlock() : void
@@ -46,12 +46,12 @@ final class BlockTests extends TestCase
         $this->assertTrue($block->isValid());
 
         // Previous hash matches
-        $this->assertEquals($block->getPreviousHash(), $lastBlock->getHash());
+        $this->assertSame($lastBlock->getHash(), $block->getPreviousHash());
 
         // Index is incremented
-        $this->assertEquals($block->getIndex(), $lastBlock->getIndex() + 1);
+        $this->assertSame($lastBlock->getIndex() + 1, $block->getIndex());
 
         // Can get same data back
-        $this->assertEquals($block->getData(), $testData);
+        $this->assertSame($testData, $block->getData());
     }
 }

--- a/tests/BlockchainTest.php
+++ b/tests/BlockchainTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  * @author Rene Korss <rene.korss@gmail.com>
  */
 
-final class BlockchainTests extends TestCase
+final class BlockchainTest extends TestCase
 {
     public function testCanCreateBlockchain() : void
     {
@@ -33,7 +33,7 @@ final class BlockchainTests extends TestCase
         $blockchain = new Blockchain();
 
         // Only has genesis block, so result should be 1
-        $this->assertEquals(1, count($blockchain));
+        $this->assertCount(1, $blockchain);
     }
 
     public function testBlockchainIsTraversable() : void


### PR DESCRIPTION
## Proposed Changes

  - Let the class name should be same as PHP file name.
  - Using the `assertCount` to assert expected count is same as result count.
  - The `assertSame` parameter orders are `$expected, $actual, $message` and it should be changed.
